### PR TITLE
New inputs and outputs

### DIFF
--- a/.github/workflows/reusable-terraform-pr-plan.yml
+++ b/.github/workflows/reusable-terraform-pr-plan.yml
@@ -28,6 +28,9 @@ on:
       has-changes:
         description: "Whether any stack has changes"
         value: ${{ jobs.summarize.outputs.has-changes }}
+      stacks:
+        description: "JSON array of all stacks that were planned"
+        value: ${{ jobs.determine-changed-stacks.outputs.all-stacks }}
 
 defaults:
   run:


### PR DESCRIPTION
- `selected-stacks` can be useful for running the workflow outside of a PR context in the future
- `ignored-stacks` can be useful for always skipping certain stacks
- `stacks` output can be useful for automerge purposes (e.g., use output for plan workflow, and run repository dispatch with the data from `stacks` as the client payload)