### PR TITLE
Refactor summary helpers into Python scripts

### DIFF
--- a/.github/workflows/reusable-terraform-pr-plan.yml
+++ b/.github/workflows/reusable-terraform-pr-plan.yml
@@ -232,6 +232,13 @@ jobs:
         working-directory: ${{ matrix.stack }}
         run: ls -lah; echo "TERRAFORM_VERSION=$(grep required_version *.tf | sed -E 's/[^"]+"([^"]+)"+/\1/')" >> "$GITHUB_OUTPUT"
 
+      - name: Extract template versions
+        id: template-version
+        run: |
+          python3 scripts/extract_template_versions.py \
+            --stack-dir "${{ matrix.stack }}" \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -393,6 +400,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           HAS_CHANGES: ${{ steps.plan-summary.outputs.result != 'No changes' }}
           SUMMARY: ${{ steps.plan-summary.outputs.result }}
+          TEMPLATE_VERSION: ${{ steps.template-version.outputs.result }}
           # Prefer comment URL for PRs, fall back to job URL
           PLAN_URL: >-
             ${{
@@ -402,20 +410,14 @@ jobs:
             }}
         id: job-summary
         run: |
-          summary="$(jq --compact-output --null-input \
-            --arg stack "$STACK" \
-            --argjson has_changes "$HAS_CHANGES" \
-            --arg job_status "$JOB_STATUS" \
-            --arg summary "$SUMMARY" \
-            --arg planUrl "$PLAN_URL" \
-            '{stack: $stack, hasChanges: $has_changes, jobStatus: $job_status, summary: $summary, planUrl: $planUrl}'
-          )"
-
-          artifact_name="summary-$(echo "$STACK" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--/-/g')"
-          job_summary_file="/tmp/$artifact_name.json"
-          echo "$summary" > "$job_summary_file"
-          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
-          echo "file=$job_summary_file" >> "$GITHUB_OUTPUT"
+          python3 scripts/write_job_summary.py \
+            --stack "$STACK" \
+            --job-status "$JOB_STATUS" \
+            --has-changes "$HAS_CHANGES" \
+            --summary "$SUMMARY" \
+            --template-version "$TEMPLATE_VERSION" \
+            --plan-url "$PLAN_URL" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Store job summary as artifact
         if: ${{ always() }}
@@ -454,76 +456,14 @@ jobs:
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         id: summary
         run: |
-          timestamp=$(date +"%a %d. %b %T")
-          short_sha="$(echo "$COMMIT_SHA" | cut -c-8)"
-          stack_total=$(echo "${STACKS:-[]}" | jq 'length')
-          stack_word="stacks"
-          if [ "$stack_total" -eq 1 ]; then
-            stack_word="stack"
-          fi
-          summary="## Summary (${stack_total} $stack_word)"
-
-          create_table="false"
-          for f in summaries/*.json; do
-            [ -e "$f" ] && create_table="true" && break
-          done
-
-          if [ "$create_table" = "true" ]; then
-            summary="$(printf "%s\n%s\n" "$summary" "| Status | Stack | Details |")"
-            summary="$(printf "%s\n%s\n" "$summary" "|:---:|------------|------------|")"
-          fi
-
-          success="true"
-          has_changes="false"
-
-          for summary_file in summaries/*.json; do
-            emoji="❌"
-            stack="$(jq -r -e '.stack' "$summary_file")"
-            plan_url="$(jq -r '.planUrl' "$summary_file")"
-            plan_summary="$(jq -r -e '.summary' "$summary_file")"
-
-            if "$(jq -e '.jobStatus == "success"' "$summary_file")"; then
-              emoji="🟩"
-              if "$(jq -e '.hasChanges' "$summary_file")"; then
-                emoji="🟧"
-                has_changes="true"
-              fi
-            else
-              plan_summary="Plan failed"
-              success="false"
-            fi
-
-            if [ "$plan_url" != "" ]; then
-              summary="$(printf "%s\n|%s|%s|%s|\n" "$summary" "$emoji" "[\`$stack\`]($plan_url)" "$plan_summary")"
-            else
-              summary="$(printf "%s\n|%s|%s|%s|\n" "$summary" "$emoji" "\`$stack\`" "$plan_summary")"
-            fi
-          done
-
-          # Build PR-specific content
-          if [ "$IS_PULL_REQUEST" = "true" ]; then
-            cat <<EOF > /tmp/summary.md
-          $summary
-          <!--terraform-pr-github-run-id:$GITHUB_RUN_ID-->
-          <!--terraform-pr-summary-->
-
-          ---
-
-          - [ ] Check this box to recreate plans <!--terraform-pr-recreate-->
-
-          _Time: ${timestamp}, commit: ${short_sha}_
-          EOF
-          else
-            cat <<EOF > /tmp/summary.md
-          $summary
-
-          _Time: ${timestamp}, commit: ${short_sha}_
-          EOF
-          fi
-
-          echo "file=/tmp/summary.md" >> "$GITHUB_OUTPUT"
-          echo "success=$success" >> "$GITHUB_OUTPUT"
-          echo "has-changes=$has_changes" >> "$GITHUB_OUTPUT"
+          python3 scripts/build_summary.py \
+            --summaries-dir summaries \
+            --stacks-json "${STACKS:-[]}" \
+            --github-run-id "$GITHUB_RUN_ID" \
+            --commit-sha "$COMMIT_SHA" \
+            --is-pull-request "$IS_PULL_REQUEST" \
+            --output-file /tmp/summary.md \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Write to job summary
         if: ${{ github.event_name != 'pull_request' }}

--- a/scripts/build_summary.py
+++ b/scripts/build_summary.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+def parse_bool(value: str) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def env_rank(stack: str) -> int:
+    if "/dev/" in stack:
+        return 0
+    if "/prod/" in stack:
+        return 1
+    return 2
+
+
+def normalize_stack(stack: str) -> str:
+    return stack.replace("/dev/", "/", 1).replace("/prod/", "/", 1)
+
+
+def write_github_output(path: Path, key: str, value: str) -> None:
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a combined summary markdown file.")
+    parser.add_argument("--summaries-dir", default="summaries")
+    parser.add_argument("--stacks-json", default="[]")
+    parser.add_argument("--github-run-id", required=True)
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--is-pull-request", required=True)
+    parser.add_argument("--output-file", required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    try:
+        stacks = json.loads(args.stacks_json) if args.stacks_json else []
+    except json.JSONDecodeError:
+        stacks = []
+
+    stack_total = len(stacks)
+    stack_word = "stack" if stack_total == 1 else "stacks"
+
+    summary_lines = [f"## Summary ({stack_total} {stack_word})"]
+
+    summaries_dir = Path(args.summaries_dir)
+    summary_files = list(summaries_dir.glob("*.json"))
+    create_table = len(summary_files) > 0
+
+    success = True
+    has_changes = False
+
+    if create_table:
+        summary_lines.append("| Status | Stack | Template | Details |")
+        summary_lines.append("|:---:|------------|----------------|------------|")
+
+        rows = []
+        for summary_file in summary_files:
+            try:
+                rows.append(json.loads(summary_file.read_text(encoding="utf-8")))
+            except json.JSONDecodeError:
+                continue
+
+        rows.sort(key=lambda row: (normalize_stack(str(row.get("stack", ""))), env_rank(str(row.get("stack", ""))), str(row.get("stack", ""))))
+
+        for row in rows:
+            emoji = "❌"
+            stack = str(row.get("stack", ""))
+            plan_url = row.get("planUrl") or ""
+            plan_summary = row.get("summary") or ""
+            template_version = row.get("templateVersion") or "-"
+            job_status = row.get("jobStatus") or ""
+            row_has_changes = bool(row.get("hasChanges"))
+
+            if job_status == "success":
+                emoji = "🟩"
+                if row_has_changes:
+                    emoji = "🟧"
+                    has_changes = True
+            else:
+                plan_summary = "Plan failed"
+                success = False
+
+            if not template_version:
+                template_version = "-"
+
+            if plan_url:
+                stack_cell = f"[`{stack}`]({plan_url})"
+            else:
+                stack_cell = f"`{stack}`"
+
+            summary_lines.append(f"|{emoji}|{stack_cell}|{template_version}|{plan_summary}|")
+
+    summary = "\n".join(summary_lines)
+    timestamp = datetime.now().strftime("%a %d. %b %T")
+    short_sha = args.commit_sha[:8] if args.commit_sha else ""
+
+    if parse_bool(args.is_pull_request):
+        content = "\n".join(
+            [
+                summary,
+                f"<!--terraform-pr-github-run-id:{args.github_run_id}-->",
+                "<!--terraform-pr-summary-->",
+                "",
+                "---",
+                "",
+                "- [ ] Check this box to recreate plans <!--terraform-pr-recreate-->",
+                "",
+                f"_Time: {timestamp}, commit: {short_sha}_",
+                "",
+            ]
+        )
+    else:
+        content = "\n".join(
+            [
+                summary,
+                "",
+                f"_Time: {timestamp}, commit: {short_sha}_",
+                "",
+            ]
+        )
+
+    output_file = Path(args.output_file)
+    output_file.write_text(content, encoding="utf-8")
+
+    if args.github_output:
+        github_output = Path(args.github_output)
+        write_github_output(github_output, "file", str(output_file))
+        write_github_output(github_output, "success", str(success).lower())
+        write_github_output(github_output, "has-changes", str(has_changes).lower())
+
+    print(str(output_file))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_template_versions.py
+++ b/scripts/extract_template_versions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def clean_value(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    value = re.split(r"\s+#", value, 1)[0].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        value = value[1:-1]
+    return value.strip()
+
+
+def extract_boilerplate_versions(stack_dir: Path) -> list[str]:
+    versions: list[str] = []
+    boilerplate_dir = stack_dir / ".boilerplate"
+    if not boilerplate_dir.is_dir():
+        return versions
+    for path in sorted(boilerplate_dir.glob("_template_*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        name = str(data.get("name") or "").strip()
+        version = str(data.get("version") or "").strip()
+        if version:
+            entry = f"{name}@{version}" if name else version
+            versions.append(entry)
+    return versions
+
+
+def parse_packages_file(path: Path) -> list[str]:
+    entries: list[str] = []
+    in_packages = False
+    template = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("#"):
+            continue
+        if re.match(r"^\s*Packages\s*:", line):
+            in_packages = True
+            continue
+        if not in_packages:
+            continue
+        template_match = re.match(r"^\s*Template\s*:\s*(.+)$", line)
+        if template_match:
+            template = clean_value(template_match.group(1))
+            continue
+        ref_match = re.match(r"^\s*Ref\s*:\s*(.+)$", line)
+        if ref_match:
+            ref = clean_value(ref_match.group(1))
+            if ref:
+                entry = ref
+                if template:
+                    pattern = rf"^{re.escape(template)}[-_]?v?(.+)$"
+                    match = re.match(pattern, ref)
+                    if match:
+                        entry = f"{template}@{match.group(1)}"
+                    else:
+                        entry = f"{template}@{ref}"
+                entries.append(entry)
+            template = ""
+            continue
+    return entries
+
+
+def extract_packages_versions(stack_dir: Path) -> list[str]:
+    for filename in ("packages.yml", "packages.yaml"):
+        path = stack_dir / filename
+        if path.is_file():
+            return parse_packages_file(path)
+    return []
+
+
+def dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def write_github_output(path: Path, key: str, value: str) -> None:
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract template versions for a stack.")
+    parser.add_argument("--stack-dir", default=".", help="Path to the stack directory.")
+    parser.add_argument("--github-output", help="Path to GITHUB_OUTPUT to write key=value.")
+    parser.add_argument("--output-key", default="result", help="Output key for GITHUB_OUTPUT.")
+    parser.add_argument("--output-file", help="Optional file to write the versions string.")
+    args = parser.parse_args()
+
+    stack_dir = Path(args.stack_dir)
+    versions = extract_boilerplate_versions(stack_dir) + extract_packages_versions(stack_dir)
+    versions = dedupe(versions)
+    result = ", ".join(versions) if versions else "-"
+
+    if args.output_file:
+        Path(args.output_file).write_text(result + "\n", encoding="utf-8")
+
+    if args.github_output:
+        write_github_output(Path(args.github_output), args.output_key, result)
+
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_job_summary.py
+++ b/scripts/write_job_summary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def parse_bool(value: str) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def sanitize_artifact_name(stack: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9-]", "-", stack)
+    cleaned = re.sub(r"-{2,}", "-", cleaned)
+    return f"summary-{cleaned}"
+
+
+def write_github_output(path: Path, key: str, value: str) -> None:
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write a per-stack summary JSON artifact.")
+    parser.add_argument("--stack", required=True)
+    parser.add_argument("--job-status", required=True)
+    parser.add_argument("--has-changes", required=True)
+    parser.add_argument("--summary", default="")
+    parser.add_argument("--template-version", default="-")
+    parser.add_argument("--plan-url", default="")
+    parser.add_argument("--output-dir", default="/tmp")
+    parser.add_argument("--output-file")
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    has_changes = parse_bool(args.has_changes)
+    artifact_name = sanitize_artifact_name(args.stack)
+    output_file = Path(args.output_file) if args.output_file else Path(args.output_dir) / f"{artifact_name}.json"
+
+    payload = {
+        "stack": args.stack,
+        "hasChanges": has_changes,
+        "jobStatus": args.job_status,
+        "summary": args.summary,
+        "templateVersion": args.template_version,
+        "planUrl": args.plan_url,
+    }
+
+    output_file.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+
+    if args.github_output:
+        github_output = Path(args.github_output)
+        write_github_output(github_output, "artifact-name", artifact_name)
+        write_github_output(github_output, "file", str(output_file))
+
+    print(str(output_file))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
- Refactor template version extraction + summary generation into composable Python scripts (stdlib only).
- Keep summary table behavior: add Template column and sort dev/prod next to each other for easier diffing.

## Why
- Easier to read, test, and reuse than embedded bash/jq/awk.

## Example table
| Status | Stack | Template | Details |
|:---:|------------|----------------|------------|
|🟩|`stacks/dev/app-foo`|app@10.2.2|No changes|
|🟧|`stacks/prod/app-foo`|app@10.2.1|1 to add, 0 to change, 0 to destroy|
|🟩|`stacks/dev/app-bar`|app@10.2.2|No changes|
|🟩|`stacks/prod/app-bar`|app@10.2.2|No changes|
